### PR TITLE
Add missing dependencies for dvb_usb_dvbsky

### DIFF
--- a/dvb-firmware/Makefile
+++ b/dvb-firmware/Makefile
@@ -94,4 +94,19 @@ endef
 $(eval $(call BuildPackage,ngene-firmware))
 
 
+Package/si2168-firmware = $(call Package/firmware-default,Silicon Labs Si2168)
+define Package/si2168-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-01.fw \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-02.fw \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-a20-01.fw \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-a30-01.fw \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-b40-01.fw \
+		$(PKG_BUILD_DIR)/firmware/dvb-demod-si2168-d60-01.fw \
+		$(1)/lib/firmware
+endef
+$(eval $(call BuildPackage,si2168-firmware))
+
+
 #$(eval $(call BuildPackage,dvb-firmware))

--- a/v4l-dvb/frontends.mk
+++ b/v4l-dvb/frontends.mk
@@ -74,7 +74,7 @@ $(eval $(call KernelPackage,dvb-rtl2832))
 define KernelPackage/dvb-si2168
   TITLE := Silicon Labs Si2168
   $(call DvbFrontend,si2168,CONFIG_DVB_SI2168)
-  DEPENDS += +kmod-i2c-mux +si2168-firmware
+  DEPENDS += +kmod-i2c-mux
 endef
 
 define KernelPackage/dvb-si2168/description

--- a/v4l-dvb/frontends.mk
+++ b/v4l-dvb/frontends.mk
@@ -388,3 +388,27 @@ define KernelPackage/dvb-stb6100/description
 endef
 
 $(eval $(call KernelPackage,dvb-stb6100))
+
+
+define KernelPackage/dvb-sp2
+  TITLE := CIMaX SP2/SP2HF CI
+  $(call DvbFrontend,sp2,CONFIG_DVB_SP2)
+endef
+
+define KernelPackage/dvb-sp2/description
+ CIMaX SP2/SP2HF Common Interface module.
+endef
+
+$(eval $(call KernelPackage,dvb-sp2))
+
+
+define KernelPackage/dvb-ts2020
+  TITLE := Montage Tehnology TS2020 based tuners
+  $(call DvbFrontend,ts2020,CONFIG_DVB_TS2020)
+endef
+
+define KernelPackage/dvb-ts2020/description
+ A DVB-S/S2 silicon tuner. Say Y when you want to support this tuner.
+endef
+
+$(eval $(call KernelPackage,dvb-ts2020))

--- a/v4l-dvb/frontends.mk
+++ b/v4l-dvb/frontends.mk
@@ -74,7 +74,7 @@ $(eval $(call KernelPackage,dvb-rtl2832))
 define KernelPackage/dvb-si2168
   TITLE := Silicon Labs Si2168
   $(call DvbFrontend,si2168,CONFIG_DVB_SI2168)
-  DEPENDS += +kmod-i2c-mux
+  DEPENDS += +kmod-i2c-mux +si2168-firmware
 endef
 
 define KernelPackage/dvb-si2168/description

--- a/v4l-dvb/usb.mk
+++ b/v4l-dvb/usb.mk
@@ -167,7 +167,7 @@ define KernelPackage/dvb-usb-dvbsky
   V4L_KCONFIG := CONFIG_DVB_USB_DVBSKY
   FILES := $(PKG_BUILD_DIR)/v4l/dvb-usb-dvbsky.ko
   AUTOLOAD := $(call AutoProbe,dvb-usb-dvbsky)
-  $(call AddDepends/dvb-usb-v2,+kmod-dvb-si2168 +kmod-media-tuner-si2157 +kmod-dvb-m88ds3103 +kmod-dvb-sp2 +kmod-dvb-ts2020)
+  $(call AddDepends/dvb-usb-v2,+kmod-dvb-si2168 +kmod-dvb-m88ds3103)
 endef
 
 define KernelPackage/dvb-usb-dvbsky/description

--- a/v4l-dvb/usb.mk
+++ b/v4l-dvb/usb.mk
@@ -167,7 +167,7 @@ define KernelPackage/dvb-usb-dvbsky
   V4L_KCONFIG := CONFIG_DVB_USB_DVBSKY
   FILES := $(PKG_BUILD_DIR)/v4l/dvb-usb-dvbsky.ko
   AUTOLOAD := $(call AutoProbe,dvb-usb-dvbsky)
-  $(call AddDepends/dvb-usb-v2,+kmod-dvb-si2168 +kmod-dvb-m88ds3103)
+  $(call AddDepends/dvb-usb-v2,+kmod-dvb-si2168 +kmod-media-tuner-si2157 +kmod-dvb-m88ds3103 +kmod-dvb-sp2 +kmod-dvb-ts2020)
 endef
 
 define KernelPackage/dvb-usb-dvbsky/description


### PR DESCRIPTION
I have a hard time getting my new TT-connect CT-4650 CI down to work with the dvb_usb_dvbsky driver. Some of the dependent modules were not selected in menuconfig so devices under /dev/dvb/adapterN did not show up while there was no warning message. I spent many hours for the trivial answer. We should add all dependencies based on upstream.