### PR TITLE
README.md: warn that a device may require a set of independent modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ Run 'make' to build with package defaults or 'make menuconfig'
 to select build options, and then 'make' to build it.
 Sugestions, improvements are welcomed.
 Have Fun.
+
+Keep in mind that a real device may require a **set of modules** to operate
+which might **are not selected together** automatically. Do not forget to
+select all of them by hand. You can use linuxtv.org's wiki to determinate
+what components are used by your device.


### PR DESCRIPTION
Who are not familiar in the DVB subsystem might not be aware of that fact
that a real device may require a set of modules to operate which might
are not selected together automatically when one part selected.
A short paragraph in the README can save those users from confusion.