### PR TITLE
README.md: clarify Kernel modules > Video Support conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Keep in mind that a real device may require a **set of modules** to operate
 which might **are not selected together** automatically. Do not forget to
 select all of them by hand. You can use linuxtv.org's wiki to determinate
 what components are used by your device.
+
+It is strongly recommended to say "N" in menuconfig to the following:
+`Kernel modules > Video Support > kmod-video-core`. Otherwise you may
+be faced with building error.


### PR DESCRIPTION
Using media modules from the mainline kernel is not recommended when
v4l-dvb is in use, because it is very likely that conflict will arise.

If it becomes necessary it'd be still better to provide camera support
based on used media tree rather going into a complex interaction with
mainline media modules.