### PR TITLE
v4l-dvb: Use correct make flags

### DIFF
--- a/v4l-dvb/Makefile
+++ b/v4l-dvb/Makefile
@@ -28,6 +28,11 @@ MAKE_VARS += \
 	DIR=$(LINUX_DIR) \
 	SRCDIR=$(LINUX_DIR)
 
+MAKE_FLAGS += \
+	$(TARGET_CONFIGURE_OPTS) \
+	CROSS="$(TARGET_CROSS)" \
+	ARCH="$(LINUX_KARCH)" \
+
 define Build/Prepare
 	$(call Build/Prepare/Default)
 
@@ -47,7 +52,8 @@ define Build/Prepare
 endef
 
 define Build/Configure
-	$(call Build/Compile/Default,allyesconfig)
+	$(call Build/Compile/Default,allyesconfig) \
+	cat ./v4l_config >> $(PKG_BUILD_DIR)/v4l/.config;
 endef
 
 define Build/InstallDev

--- a/v4l-dvb/Makefile
+++ b/v4l-dvb/Makefile
@@ -52,8 +52,7 @@ define Build/Prepare
 endef
 
 define Build/Configure
-	$(call Build/Compile/Default,allyesconfig) \
-	cat ./v4l_config >> $(PKG_BUILD_DIR)/v4l/.config;
+	$(call Build/Compile/Default,allyesconfig)
 endef
 
 define Build/InstallDev

--- a/v4l-dvb/Makefile
+++ b/v4l-dvb/Makefile
@@ -31,7 +31,7 @@ MAKE_VARS += \
 MAKE_FLAGS += \
 	$(TARGET_CONFIGURE_OPTS) \
 	CROSS="$(TARGET_CROSS)" \
-	ARCH="$(LINUX_KARCH)" \
+	ARCH="$(LINUX_KARCH)"
 
 define Build/Prepare
 	$(call Build/Prepare/Default)


### PR DESCRIPTION
I was running into issues where compilation would fail because it thought the architecture was `aarch64` instead of `arm64`. This patch seems to fix it.